### PR TITLE
401 fix?

### DIFF
--- a/resources/js/client/src/router/index.js
+++ b/resources/js/client/src/router/index.js
@@ -105,6 +105,8 @@ const router = createRouter({
 router.beforeEach(async (to, from) => {
     const authStore = useAuthStore();
 
+    await authStore.verifySession()
+
     if (authStore.user && to.meta.guest) {
         return { name: 'app.dashboard' };
     }

--- a/resources/js/client/src/stores/auth.js
+++ b/resources/js/client/src/stores/auth.js
@@ -1,7 +1,7 @@
-import axios from "@/lib/axios";
-import { defineStore } from "pinia";
+import axios from '@/lib/axios';
+import { defineStore } from 'pinia';
 
-export const useAuthStore = defineStore("auth", {
+export const useAuthStore = defineStore('auth', {
     state: () => ({
         authUser: null,
         isAuthenticated: false,
@@ -24,7 +24,7 @@ export const useAuthStore = defineStore("auth", {
             this.authErrors = {};
         },
         async fetchCsrfCookie() {
-            await axios.get("/sanctum/csrf-cookie");
+            await axios.get('/sanctum/csrf-cookie');
         },
         async cleanState() {
             this.authUser = null;
@@ -34,7 +34,7 @@ export const useAuthStore = defineStore("auth", {
             // if (this.processing) return;
             this.processing = true;
             try {
-                const response = await axios.get("/api/user");
+                const response = await axios.get('/api/user');
                 this.authUser = response.data;
                 this.isAuthenticated = true;
             } catch (error) {
@@ -49,9 +49,9 @@ export const useAuthStore = defineStore("auth", {
             this.processing = true;
             try {
                 await this.fetchCsrfCookie();
-                await axios.post("/register", data);
+                await axios.post('/register', data);
                 await this.fetchUser();
-                this.router.replace({ name: "app.dashboard" });
+                this.router.replace({ name: 'app.dashboard' });
             } catch (error) {
                 if (error.response?.status === 422) {
                     this.authErrors = error.response.data.errors;
@@ -65,9 +65,9 @@ export const useAuthStore = defineStore("auth", {
             this.processing = true;
             try {
                 await this.fetchCsrfCookie();
-                await axios.post("/login", data);
+                await axios.post('/login', data);
                 await this.fetchUser();
-                this.router.replace({ name: "app.dashboard" });
+                this.router.replace({ name: 'app.dashboard' });
             } catch (error) {
                 console.log(error);
                 if (error.response?.status === 422) {
@@ -79,11 +79,11 @@ export const useAuthStore = defineStore("auth", {
         },
         async logout() {
             try {
-                await axios.post("/api/logout");
+                await axios.post('/api/logout');
             } finally {
                 this.cleanState();
                 this.clearErrors();
-                this.router.replace({ name: "login" });
+                this.router.replace({ name: 'login' });
             }
         },
     },


### PR DESCRIPTION
> The problem occurs on pages where authentication is not required. When a user is not logged in, the API returns a 401 error instead of allowing access. However, once logged in, everything works fine.

I'm not sure I understood the original problem (when a user is not logged in, you should, indeed receive a 401 response), but I did notice there's nothing loading the user when a full page load/refresh happens.

Basically, when you log in via the login form, the user is added in the pinia store. But when you refresh the page, the store starts out clean, so you need to "fill" it with the user again -> make a request to fetch the user - this only happens on full page load/reloads.

The "isSessionVerified" is added to ensure you don't try and fetch the user with every subsequent vue-router navigations.

Let me know if this fixes it or if I misunderstood the problem.

Good luck!
